### PR TITLE
Ikke tilgang

### DIFF
--- a/src/components/aarsaker-til-at-personen-ikke-kan-registreres-v2.tsx
+++ b/src/components/aarsaker-til-at-personen-ikke-kan-registreres-v2.tsx
@@ -59,10 +59,10 @@ function AarsakerTilAtPersonenIkkeKanRegistreres(props: AarsakerProps) {
 
     if (!feilmelding) return null;
 
-    const aarsaker = aarsakTilAvvisning.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
+    const aarsaker = aarsakTilAvvisning?.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
     const reglerSomKanOverstyres = aarsaker.filter((regel) => !REGLER_SOM_IKKE_KAN_OVERSTYRES.includes(regel));
     const kanAlleReglerIkkeOverstyres = reglerSomKanOverstyres.length === 0;
-    const ansattHarIkkeTilgang = aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER');
+    const ansattHarIkkeTilgang = aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER', 'IKKE_TILGANG');
 
     if (!aarsaker || !kanAlleReglerIkkeOverstyres) return null;
 

--- a/src/components/aarsaker-til-at-personen-ikke-kan-registreres-v2.tsx
+++ b/src/components/aarsaker-til-at-personen-ikke-kan-registreres-v2.tsx
@@ -80,6 +80,11 @@ function AarsakerTilAtPersonenIkkeKanRegistreres(props: AarsakerProps) {
                         Hva må ordnes før du kan registrere personen?
                     </Heading>
                     <BodyLong spacing>Du må få korrekt tilgang til vedkommende alle aktuelle opplysninger.</BodyLong>
+                    <List as="ul" title="Dette kan du gjøre">
+                        <List.Item>
+                            Ta kontakt med din lokale identansvarlig. Dette er vanligvis enhetens leder.
+                        </List.Item>
+                    </List>
                 </>
             )}
             {!ansattHarIkkeTilgang && (
@@ -88,13 +93,13 @@ function AarsakerTilAtPersonenIkkeKanRegistreres(props: AarsakerProps) {
                         Hva må ordnes før personen kan registreres?
                     </Heading>
                     <BodyLong spacing>Personen kan ikke registreres før registerdata er oppdatert.</BodyLong>
+                    <List as="ul" title="Dette kan du gjøre">
+                        {tiltaksliste.map((tiltak) => (
+                            <List.Item key={tiltak.id}>{tiltak.beskrivelse}</List.Item>
+                        ))}
+                    </List>
                 </>
             )}
-            <List as="ul" title="Dette kan du gjøre">
-                {tiltaksliste.map((tiltak) => (
-                    <List.Item key={tiltak.id}>{tiltak.beskrivelse}</List.Item>
-                ))}
-            </List>
         </Box>
     );
 }

--- a/src/components/aarsaker-til-at-personen-ikke-kan-registreres-v2.tsx
+++ b/src/components/aarsaker-til-at-personen-ikke-kan-registreres-v2.tsx
@@ -55,14 +55,15 @@ const TILTAKSLISTE = {
 
 function AarsakerTilAtPersonenIkkeKanRegistreres(props: AarsakerProps) {
     const { feilmelding } = props;
-    const { aarsakTilAvvisning } = feilmelding || {};
+    const { aarsakTilAvvisning, feilKode } = feilmelding || {};
 
     if (!feilmelding) return null;
 
     const aarsaker = aarsakTilAvvisning?.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
     const reglerSomKanOverstyres = aarsaker.filter((regel) => !REGLER_SOM_IKKE_KAN_OVERSTYRES.includes(regel));
     const kanAlleReglerIkkeOverstyres = reglerSomKanOverstyres.length === 0;
-    const ansattHarIkkeTilgang = aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER', 'IKKE_TILGANG');
+    const ansattHarIkkeTilgang =
+        aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER', 'IKKE_TILGANG') || feilKode === 'IKKE_TILGANG';
 
     if (!aarsaker || !kanAlleReglerIkkeOverstyres) return null;
 
@@ -73,6 +74,14 @@ function AarsakerTilAtPersonenIkkeKanRegistreres(props: AarsakerProps) {
 
     return (
         <Box>
+            {ansattHarIkkeTilgang && (
+                <>
+                    <Heading level="2" size="small">
+                        Hva må ordnes før du kan registrere personen?
+                    </Heading>
+                    <BodyLong spacing>Du må få korrekt tilgang til vedkommende alle aktuelle opplysninger.</BodyLong>
+                </>
+            )}
             {!ansattHarIkkeTilgang && (
                 <>
                     <Heading level="2" size="small">

--- a/src/components/kan-registreres-som-arbeidssoeker-sjekk-v2.tsx
+++ b/src/components/kan-registreres-som-arbeidssoeker-sjekk-v2.tsx
@@ -11,8 +11,8 @@ function Feilmelding(props: FeilmeldingProps) {
 
     if (!feilmelding) return null;
 
-    const aarsaker = aarsakTilAvvisning.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
-    const duManglerTilgang = aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER');
+    const aarsaker = aarsakTilAvvisning?.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
+    const duManglerTilgang = aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER', 'IKKE_TILGANG');
 
     return (
         <Alert variant="warning" className="mb-8">

--- a/src/components/kan-registreres-som-arbeidssoeker-sjekk-v2.tsx
+++ b/src/components/kan-registreres-som-arbeidssoeker-sjekk-v2.tsx
@@ -8,11 +8,12 @@ interface FeilmeldingProps {
 function Feilmelding(props: FeilmeldingProps) {
     const { feilmelding } = props;
     const { aarsakTilAvvisning } = feilmelding || {};
+    const { feilKode } = feilmelding || {};
 
     if (!feilmelding) return null;
 
     const aarsaker = aarsakTilAvvisning?.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
-    const duManglerTilgang = aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER', 'IKKE_TILGANG');
+    const duManglerTilgang = aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER') || feilKode === 'IKKE_TILGANG';
 
     return (
         <Alert variant="warning" className="mb-8">

--- a/src/components/velg-registreringsknapp-v2.tsx
+++ b/src/components/velg-registreringsknapp-v2.tsx
@@ -17,7 +17,15 @@ interface RegistreringsknappProps {
 
 function VelgRegistreringsKnapp(props: RegistreringsknappProps) {
     const { feilmelding, kanStarteArbeidssoekerperiode } = props;
+    const { aarsakTilAvvisning, feilKode } = feilmelding || {};
+    const aarsaker = aarsakTilAvvisning?.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
+    const ansattHarIkkeTilgang =
+        aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER', 'IKKE_TILGANG') || feilKode === 'IKKE_TILGANG';
     const kanOverstyres = sjekkOmAlleReglerKanOverstyres(feilmelding);
+
+    if (ansattHarIkkeTilgang) {
+        return null;
+    }
 
     if (kanStarteArbeidssoekerperiode) {
         return <StartPeriodeKnapp />;

--- a/src/components/vurderingskriterier-for-arbeidssoekerregistrering-v2.tsx
+++ b/src/components/vurderingskriterier-for-arbeidssoekerregistrering-v2.tsx
@@ -39,7 +39,7 @@ function VurderingskriterierForArbeidssoekerregistrering(props: Vurderingskriter
 
     if (!feilmelding) return null;
 
-    const aarsaker = aarsakTilAvvisning.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
+    const aarsaker = aarsakTilAvvisning?.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
     const reglerSomIkkeKanOverstyres = aarsaker.filter((regel) => !REGLER_SOM_KAN_OVERSTYRES.includes(regel));
     const kanAlleReglerOverstyres = reglerSomIkkeKanOverstyres.length === 0;
 

--- a/src/components/vurderingskriterier-for-arbeidssoekerregistrering-v2.tsx
+++ b/src/components/vurderingskriterier-for-arbeidssoekerregistrering-v2.tsx
@@ -35,15 +35,17 @@ const TILTAKSLISTE = {
 
 function VurderingskriterierForArbeidssoekerregistrering(props: VurderingskriterierProps) {
     const { feilmelding } = props;
-    const { aarsakTilAvvisning } = feilmelding || {};
+    const { aarsakTilAvvisning, feilKode } = feilmelding || {};
 
     if (!feilmelding) return null;
 
     const aarsaker = aarsakTilAvvisning?.regler ? aarsakTilAvvisning.regler.map((regel) => regel.id) : [];
     const reglerSomIkkeKanOverstyres = aarsaker.filter((regel) => !REGLER_SOM_KAN_OVERSTYRES.includes(regel));
     const kanAlleReglerOverstyres = reglerSomIkkeKanOverstyres.length === 0;
+    const ansattHarIkkeTilgang =
+        aarsaker.includes('ANSATT_IKKE_TILGANG_TIL_BRUKER', 'IKKE_TILGANG') || feilKode === 'IKKE_TILGANG';
 
-    if (!aarsaker || !kanAlleReglerOverstyres) return null;
+    if (!aarsaker || !kanAlleReglerOverstyres || ansattHarIkkeTilgang) return null;
 
     const tiltaksliste = aarsaker.reduce((liste, regel) => {
         liste.push(...TILTAKSLISTE[regel]);

--- a/src/pages/api/mocks/kan-starte-arbeidssoekerperiode-v2.ts
+++ b/src/pages/api/mocks/kan-starte-arbeidssoekerperiode-v2.ts
@@ -142,7 +142,7 @@ const IKKE_FUNNET = {
 /*
 // Feilmelding for ansatt som ikke har tilgang
 const kanStarteArbeidssoekerperiode = (req: NextApiRequest, res: NextApiResponse): void => {
-    res.status(403).json(ANSATT_IKKE_TILGANG_TIL_BRUKER);
+    res.status(403).json(IKKE_TILGANG);
 };
 
 
@@ -157,6 +157,15 @@ const ANSATT_IKKE_TILGANG_TIL_BRUKER = {
     feilKode: "AVVIST",
     melding: "Ansatt har ikke tilgang til bruker",
     status: 403
+}
+
+
+const IKKE_TILGANG = {
+    "melding": "Ansatt har ikke tilgang til bruker",
+    "feilKode": "IKKE_TILGANG",
+    "aarsakTilAvvisning": null,
+    "status": 403,
+    "traceId": "366405889beebb5060006b15e9dcbe87"
 }
 */
 


### PR DESCRIPTION
Fikser logikken for tilfellene der veileder ikke har tilgang til personen.
Baserer seg på feilKode i stedet for regler som aldri ville inneholdt det nødvendige.
Skjuler informasjon og valg som ikke er relevant når tilgang mangler og gir tilbakemeldinger i skjermbildet om hvordan veileder kan rette tilgangen. 